### PR TITLE
extract the filename more dynamically; Follow-up to #13 for Bonus_Spectra_MRD

### DIFF
--- a/bonusSpectraCalibration_v2303.m
+++ b/bonusSpectraCalibration_v2303.m
@@ -33,11 +33,9 @@ file_with_path = strcat(path, file);  % join path and filename to open
 [~, base, ext] = fileparts(file_with_path);
 isTwix = strcmpi(ext, '.dat');
 isMRD  = any(strcmpi(ext, {'.h5','.mrd'}));
-if isTwix
-    filename = file(15:end-4); % return filename back to something short
-else
-    filename = file(1:end-4); % return filename back to something short
-end
+parts = split(file, '.');        % split by "."
+filename = parts{1}; 
+
 cal_vars_export = [filename,'.csv']; % generate the filename for data comparison
 filename = strrep(filename, '_', '-'); % replace underscores to avoid subscript problems
 file_loc = regexp(path,filesep,'split');


### PR DESCRIPTION
The code to extract the filename should be more dynamically, like using split method to split the file by "." and generate the filename instead of hardcoding by "1:end-4". The original code is listed as following:

```
if isTwix
    filename = file(15:end-4); % return filename back to something short
else
    filename = file(1:end-4); % return filename back to something short
end
```