### PR TITLE
22-add-dedicated-shifts

### DIFF
--- a/bonusSpectraCalibration_v2303.m
+++ b/bonusSpectraCalibration_v2303.m
@@ -161,6 +161,7 @@ numSpect = numDisSpect+numGasSpect;
     idx = strcmpi({upl.name}, 'xe_dissolved_offset_frequency');
     if any(idx)
         xe_dissolved_offset_Hz = double(upl(idx).value);
+        excitation = xe_dissolved_offset_Hz;
     end
 
     % Fallback: if center freq still unknown, use first acquisition's header (common)

--- a/bonusSpectraCalibration_v2303.m
+++ b/bonusSpectraCalibration_v2303.m
@@ -414,6 +414,28 @@ fprintf('\nRbcMemRatio = %3.3f\n',RbcMemRatio); %
 GasDisRatio = disfitObj.area(3)/sum(disfitObj.area(1:2));
 fprintf('GasDisRatio = %3.3f\n',GasDisRatio); 
 
+%% Quantify chemical shift using incidental and dedicated gas references
+% Define variables for calculations
+freqs = disfitObj.freq; % [rbc membrane gas]
+rbcFreq = freqs(1); % RBC frequency in Hz
+memFreq = freqs(2); % Hz
+gasFreq = freqs(3); % Hz    
+gasOffsetFreq = gasfitObj.freq; % gas freq using dedicated gas peak rf
+
+% Calculate chemical shifts using incidental gas peak
+rbcShiftIncidental = (rbcFreq - gasFreq) / (freq * 1e-6); % rbc shift in ppm
+memShiftIncidental = (memFreq - gasFreq) / (freq * 1e-6); % membrane shift in ppm
+
+% Calculate chemical shifts using dedicated gas peak
+rbcShiftDedicated = (rbcFreq - (gasOffsetFreq - excitation)) / (freq * 1e-6); % rbc shift in ppm
+memShiftDedicated = (memFreq - (gasOffsetFreq - excitation)) / (freq * 1e-6); % membrane shift in ppm
+
+% Report values to command window
+fprintf('\nRBC shift (incidental): %3.2f\n',rbcShiftIncidental)
+fprintf('RBC shift (dedicated): %3.2f\n',rbcShiftDedicated)
+fprintf('Membrane shift (incidental): %3.2f\n',memShiftIncidental)
+fprintf('Membrane shift (dedicated): %3.2f\n',memShiftDedicated)
+
 %% Save some parameters for comparing
 folderPath = path; % save the csv file to the same directory as the dat file
 fileName = cal_vars_export; % name of the file
@@ -426,7 +448,7 @@ cal_bonus.TrueRefV = calRefVolt*calRefVoltScaleFactor; %reference voltage
 cal_bonus.TE90 = te90/1000;
 cal_bonus.RbcMemRatio = RbcMemRatio;
 cal_bonus.GasDisRatio = GasDisRatio;
-cal_bonus.RBCShift = (disfitObj.freq(1) - disfitObj.freq(3)) / freq_target * 1e6; %frequency difference between RBC and gas in ppm 
+cal_bonus.RBCShift = rbcShiftDedicated;
 cal_bonus.RBCSNR = SNRsnf_d(1);
 cal_bonus.MemSNR = SNRsnf_d(2);
 

--- a/calibration_production_v2302.m
+++ b/calibration_production_v2302.m
@@ -246,6 +246,29 @@ fprintf('\nRbcMemRatio = %3.3f\n', RbcMemRatio); %
 GasDisRatio = disfitObj.area(3) / sum(disfitObj.area(1:2));
 fprintf('GasDisRatio = %3.3f \n', GasDisRatio);
 
+%% Quantify chemical shift using incidental and dedicated gas references
+% Define variables for calculations
+freqs = disfitObj.freq; % [rbc membrane gas]
+rbcFreq = freqs(1); % RBC frequency in Hz
+memFreq = freqs(2); % Hz
+gasFreq = freqs(3); % Hz    
+disExcitationFreq = cali_struct.rf_excitation_Hz;
+gasOffsetFreq = gasfitObj.freq; % gas freq using dedicated gas peak rf
+
+% Calculate chemical shifts using incidental gas peak
+rbcShiftIncidental = (rbcFreq - gasFreq) / (freq * 1e-6); % rbc shift in ppm
+memShiftIncidental = (memFreq - gasFreq) / (freq * 1e-6); % membrane shift in ppm
+
+% Calculate chemical shifts using dedicated gas peak
+rbcShiftDedicated = (rbcFreq - (gasOffsetFreq - disExcitationFreq)) / (freq * 1e-6); % rbc shift in ppm
+memShiftDedicated = (memFreq - (gasOffsetFreq - disExcitationFreq)) / (freq * 1e-6); % membrane shift in ppm
+
+% Report values to command window
+fprintf('\nRBC shift (incidental): %3.2f\n',rbcShiftIncidental)
+fprintf('RBC shift (dedicated): %3.2f\n',rbcShiftDedicated)
+fprintf('Membrane shift (incidental): %3.2f\n',memShiftIncidental)
+fprintf('Membrane shift (dedicated): %3.2f\n',memShiftDedicated)
+
 %% Save some parameters for comparing if requested
 if save_csv == 1
     folderPath = path; % save the csv file to the same directory as the dat file
@@ -259,7 +282,7 @@ if save_csv == 1
     cal_cali.TE90 = te90;
     cal_cali.RbcMemRatio = RbcMemRatio;
     cal_cali.GasDisRatio = GasDisRatio;
-    cal_cali.RBCShift = (disfitObj.freq(1) - disfitObj.freq(3)) / freq_target * 1e6; %frequency difference between RBC and gas in ppm
+    cal_cali.RBCShift = rbcShiftDedicated;
     cal_cali.RBCSNR = SNRsnf_d(1);
     cal_cali.MemSNR = SNRsnf_d(2);
 

--- a/readRawCali.m
+++ b/readRawCali.m
@@ -15,6 +15,7 @@ function [cali_struct] = readRawCali(raw_path)
 % cali_struct.data = the FID data;
 % cali_struct.scan_date = scan date in format (YYYY-MM-DD) optional;
 % cali_struct.vref = reference voltage (V) optional;
+% cali_struct.rf_excitation_Hz = rf excitation offset in Hz;
 % cali_struct.rf_excitation_ppm = rf excitation in ppm;
 
 cali_struct = {};
@@ -95,6 +96,7 @@ switch file_extension
         cali_struct.data = twix_obj.data;
         cali_struct.scan_date = scanDateStr;
         cali_struct.vref = VRef;
+        cali_struct.rf_excitation_Hz = excitation;
         cali_struct.rf_excitation_ppm = rf_excitation_ppm;
 
     case '.h5'

--- a/readRawCali.m
+++ b/readRawCali.m
@@ -126,6 +126,7 @@ switch file_extension
 
         % calculate rf excitation in ppm
         gyro_ratio = 11.777; % gyromagnetic ratio of 129Xe in MHz/Tesla
+        cali_struct.rf_excitation_Hz = freq_dis_excitation_hz;
         cali_struct.rf_excitation_ppm = round(freq_dis_excitation_hz/(gyro_ratio * field_strength));
 
         % assign nan to variables not in mrd file


### PR DESCRIPTION
Added chemical shift calculations using dedicated gas reference frequency to both cali and bonus spectra scripts. To test, run cali/bonus spectra on array of subjects. The outputs from the cali scan should match exactly those output by dynamic spectroscopy pipeline. Functionality for both scripts should work with both twix and MRD files. 